### PR TITLE
Remove leading underlind for from pydantic

### DIFF
--- a/pygleif/api/meta.py
+++ b/pygleif/api/meta.py
@@ -16,7 +16,7 @@ class Pagination(BaseModel):
 
     current_page: int = Field(alias="currentPage")
     per_page: int = Field(alias="perPage")
-    _from: int = Field(alias="from")
+    from_: int = Field(alias="from")
     to: int = Field(alias="to")
     total: int = Field(alias="total")
     last_page: int = Field(alias="lastPage")


### PR DESCRIPTION
Hi

I get a NameError from Pzdantic for the Pagination data model. "Fields must not use names with leading underscores... _from". So i propose to name it from_.